### PR TITLE
feat: Add DeepSeek API support (deepseek-chat and deepseek-reasoner) #1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+```bash
+npm run dev    # Start development server with Wrangler
+npm run deploy # Deploy to Cloudflare Workers
+```
+
+## Project Architecture
+
+This is a Cloudflare Worker that acts as an API translation layer between Anthropic's Claude API format and OpenAI-compatible APIs (primarily OpenRouter and DeepSeek). The worker translates requests and responses bidirectionally to enable Claude Code compatibility with multiple model providers.
+
+### Core Components
+
+- **index.ts**: Main Worker entry point handling routing and orchestration
+- **formatRequest.ts**: Converts Anthropic API format to OpenAI chat completions format
+- **formatResponse.ts**: Converts OpenAI responses back to Anthropic format  
+- **streamResponse.ts**: Handles streaming response translation with proper SSE formatting
+- **env.ts**: TypeScript environment interface for Cloudflare Workers
+
+### API Translation Flow
+
+1. Receives Anthropic-format requests at `/v1/messages`
+2. Determines target provider (OpenRouter or DeepSeek) based on `DEEPSEEK_BASE_URL` environment variable
+3. `formatAnthropicToOpenAI()` converts message structure with provider-specific model mapping
+4. Forwards to configured endpoint (OpenRouter or DeepSeek)
+5. For streaming: `streamOpenAIToAnthropic()` translates SSE events in real-time
+6. For non-streaming: `formatOpenAIToAnthropic()` converts the complete response
+
+### Key Translation Logic
+
+- **Model mapping**: Maps Claude model names to provider-specific models in `formatRequest.ts:mapModel()` - supports both OpenRouter and DeepSeek
+- **Provider selection**: Automatically chooses DeepSeek if `DEEPSEEK_BASE_URL` is configured, otherwise defaults to OpenRouter
+- **Tool call validation**: Ensures proper tool_calls/tool message pairing with `validateOpenAIToolCalls()`
+- **Message structure**: Handles complex content arrays, system messages, and role differences
+- **Streaming events**: Converts OpenAI delta format to Anthropic's content block events
+
+### Environment Configuration
+
+- `OPENROUTER_BASE_URL`: OpenRouter API base URL (defaults to `https://openrouter.ai/api/v1`)
+- `DEEPSEEK_BASE_URL`: DeepSeek API base URL (when set, routes to DeepSeek instead of OpenRouter)
+- Custom domain configured: `cc.yovy.app`
+- Observability enabled for logging
+
+The worker includes static HTML pages for the homepage (`indexHtml.ts`), terms (`termsHtml.ts`), and privacy policy (`privacyHtml.ts`).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,31 @@ This allows you to use [Claude Code](https://claude.ai/code) with OpenRouter's v
 
 ## Environment Variables
 
-- `OPENROUTER_BASE_URL` (optional): Base URL for the target API. Defaults to `https://openrouter.ai/api/v1`
+- `OPENROUTER_BASE_URL` (optional): Base URL for OpenRouter API. Defaults to `https://openrouter.ai/api/v1`
+- `DEEPSEEK_BASE_URL` (optional): Base URL for DeepSeek API. When set, routes requests to DeepSeek instead of OpenRouter. Set to `https://api.deepseek.com`
+
+## Using with DeepSeek
+
+y-router now supports DeepSeek's API as an alternative to OpenRouter:
+
+1. **Get DeepSeek API key** from [platform.deepseek.com](https://platform.deepseek.com)
+
+2. **Deploy with DeepSeek configuration:**
+   ```bash
+   wrangler secret put DEEPSEEK_BASE_URL  # Set to: https://api.deepseek.com
+   ```
+
+3. **Configure Claude Code for DeepSeek:**
+   ```bash
+   export ANTHROPIC_BASE_URL="https://cc.yovy.app"
+   export ANTHROPIC_API_KEY="your-deepseek-api-key"
+   ```
+
+**Available DeepSeek Models:**
+- `deepseek-chat` - General purpose chat model
+- `deepseek-reasoner` - Advanced reasoning model
+
+Claude model requests (haiku, sonnet, opus) will automatically map to `deepseek-chat`.
 
 ## API Usage
 

--- a/env.ts
+++ b/env.ts
@@ -1,3 +1,4 @@
 export interface Env {
-  OPENROUTER_BASE_URL: string;
+  OPENROUTER_BASE_URL?: string;
+  DEEPSEEK_BASE_URL?: string;
 }

--- a/formatRequest.ts
+++ b/formatRequest.ts
@@ -98,7 +98,21 @@ function validateOpenAIToolCalls(messages: any[]): any[] {
   return validatedMessages;
 }
 
-export function mapModel(anthropicModel: string): string {
+export function mapModel(anthropicModel: string, provider: 'openrouter' | 'deepseek' = 'openrouter'): string {
+  if (provider === 'deepseek') {
+    // For DeepSeek, we map all Claude models to DeepSeek models
+    if (anthropicModel.includes('haiku') || anthropicModel.includes('sonnet') || anthropicModel.includes('opus')) {
+      return 'deepseek-chat';
+    }
+    // If it's already a DeepSeek model, return as-is
+    if (anthropicModel.includes('deepseek')) {
+      return anthropicModel;
+    }
+    // Default to deepseek-chat for other models
+    return 'deepseek-chat';
+  }
+  
+  // Original OpenRouter mapping
   if (anthropicModel.includes('haiku')) {
     return 'anthropic/claude-3.5-haiku';
   } else if (anthropicModel.includes('sonnet')) {
@@ -109,7 +123,7 @@ export function mapModel(anthropicModel: string): string {
   return anthropicModel;
 }
 
-export function formatAnthropicToOpenAI(body: MessageCreateParamsBase): any {
+export function formatAnthropicToOpenAI(body: MessageCreateParamsBase, provider: 'openrouter' | 'deepseek' = 'openrouter'): any {
   const { model, messages, system = [], temperature, tools, stream } = body;
 
   const openAIMessages = Array.isArray(messages)
@@ -213,7 +227,7 @@ export function formatAnthropicToOpenAI(body: MessageCreateParamsBase): any {
       }];
 
   const data: any = {
-    model: mapModel(model),
+    model: mapModel(model, provider),
     messages: [...systemMessages, ...openAIMessages],
     temperature,
     stream,

--- a/index.ts
+++ b/index.ts
@@ -30,10 +30,19 @@ export default {
     
     if (url.pathname === '/v1/messages' && request.method === 'POST') {
       const anthropicRequest = await request.json();
-      const openaiRequest = formatAnthropicToOpenAI(anthropicRequest);
       const bearerToken = request.headers.get("x-api-key");
 
-      const baseUrl = env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+      // Determine which provider to use based on environment variables
+      let provider: 'openrouter' | 'deepseek' = 'openrouter';
+      let baseUrl = env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+      
+      // If DeepSeek base URL is configured, use DeepSeek
+      if (env.DEEPSEEK_BASE_URL) {
+        provider = 'deepseek';
+        baseUrl = env.DEEPSEEK_BASE_URL;
+      }
+
+      const openaiRequest = formatAnthropicToOpenAI(anthropicRequest, provider);
       const openaiResponse = await fetch(`${baseUrl}/chat/completions`, {
         method: "POST",
         headers: {


### PR DESCRIPTION
## Summary
Implements support for DeepSeek's `deepseek-chat` and `deepseek-reasoner` models, enabling Claude Code users to access DeepSeek models through y-router as an alternative to OpenRouter.

## Changes Made
- **Enhanced model mapping**: Extended `formatRequest.ts:mapModel()` to support provider-specific model mapping
- **Environment variable support**: Added `DEEPSEEK_BASE_URL` to `env.ts` interface
- **Smart provider routing**: Auto-detects DeepSeek usage when `DEEPSEEK_BASE_URL` is configured
- **Model compatibility**: Maps Claude models (haiku, sonnet, opus) to `deepseek-chat`
- **Documentation updates**: Added DeepSeek setup instructions to README.md and CLAUDE.md
- **Backward compatibility**: Maintains full compatibility with existing OpenRouter configurations

## Technical Implementation
- Provider selection logic in `index.ts` chooses DeepSeek when `DEEPSEEK_BASE_URL` is set
- Extended `formatAnthropicToOpenAI()` function to accept provider parameter
- Model mapping supports both `openrouter` and `deepseek` providers
- DeepSeek API endpoint: `https://api.deepseek.com/chat/completions`

## Testing
- Development server starts without compilation errors
- Model mapping logic validated for both providers
- Environment variable handling tested

## Usage Example
```bash
# Configure for DeepSeek
export ANTHROPIC_BASE_URL="https://cc.yovy.app"
export ANTHROPIC_API_KEY="your-deepseek-api-key"
wrangler secret put DEEPSEEK_BASE_URL  # Set to: https://api.deepseek.com
```

## Documentation
- Updated README.md with DeepSeek configuration section
- Enhanced CLAUDE.md with provider selection architecture
- Added environment variable documentation

## Related Issue
Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)